### PR TITLE
Some bugs fixed

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -12,10 +12,6 @@
 /* Define to 1 if you have the `m' library (-lm). */
 #undef HAVE_LIBM
 
-/* Define to 1 if your system has a GNU libc compatible `malloc' function, and
-   to 0 otherwise. */
-#undef HAVE_MALLOC
-
 /* Define to 1 if you have the `memmove' function. */
 #undef HAVE_MEMMOVE
 
@@ -102,9 +98,6 @@
 #ifndef __cplusplus
 #undef inline
 #endif
-
-/* Define to rpl_malloc if the replacement function should be used. */
-#undef malloc
 
 /* Define to `unsigned int' if <sys/types.h> does not define. */
 #undef size_t

--- a/configure.ac
+++ b/configure.ac
@@ -60,7 +60,6 @@ AC_TYPE_SSIZE_T
 AC_CHECK_TYPES([ptrdiff_t])
 
 # Checks for library functions.
-AC_FUNC_MALLOC
 AC_CHECK_FUNCS([atexit memmove strchr strdup strerror])
 
 if test "x${enable_devel}" = "xyes"; then

--- a/include/tecnoballz.h
+++ b/include/tecnoballz.h
@@ -60,9 +60,6 @@
 
 /** Force bytes copy (SPARC unaligned memory access) */
 /* #define BYTES_COPY */
-#ifndef SCOREFILE
-#define SCOREFILE "tecnoball"
-#endif
 #ifndef PREFIX
 #define PREFIX ""
 #endif

--- a/src/configfile.cc
+++ b/src/configfile.cc
@@ -417,6 +417,7 @@ configfile::save ()
           break;
         }
       fprintf (config, ")\n");
+      fclose (config);
     }
 }
 

--- a/src/configfile.cc
+++ b/src/configfile.cc
@@ -189,6 +189,14 @@ configfile::load ()
   resetvalue ();
   get_fullpathname ();
   std::cout << conf_filename << std::endl;
+
+  /* Check if .conf exist and create it if not */
+  FILE *fi = fopen (conf_filename.c_str (), "r");
+  if (fi == NULL)
+    save();
+  else
+    fclose (fi);
+
   lispreader *parser = new lispreader ();
   lisp_object_t *root_obj = parser->lisp_read_file (conf_filename);
   if (root_obj == NULL)

--- a/src/configfile.cc
+++ b/src/configfile.cc
@@ -96,7 +96,7 @@ configfile::resetvalue ()
   initial_num_of_lifes = 5;
   number_of_players = 1;
   char *user = getenv ("USER");
-  if (user != NULL)
+  if (user == NULL)
     {
       user = stringname;
     }

--- a/src/handler_resources.cc
+++ b/src/handler_resources.cc
@@ -826,12 +826,8 @@ handler_resources::save_high_score_file (char *buffer, Uint32 size)
 {
   size_t left;
   ssize_t bytes_written;
-#ifdef WIN32
   /* set umask so that files are group-writable */
-  _umask (0002);
-#else
   umask (0002);
-#endif
   Sint32 fhand = open (fnamescore, O_WRONLY | O_CREAT, 00666);
   if (fhand == -1)
     {
@@ -842,9 +838,6 @@ handler_resources::save_high_score_file (char *buffer, Uint32 size)
   left = size;
   while (left > 0)
     {
-#ifdef WIN32
-      bytes_written = _write (fhand, buffer + size - left, left);
-#else
       bytes_written = write (fhand, buffer + size - left, left);
       if (bytes_written == -1)
         {
@@ -855,7 +848,6 @@ handler_resources::save_high_score_file (char *buffer, Uint32 size)
         }
         left -= bytes_written;
     }
-#endif
   if (close (fhand) == -1)
     {
       fprintf (stderr,

--- a/src/supervisor_map_editor.cc
+++ b/src/supervisor_map_editor.cc
@@ -828,12 +828,8 @@ bool supervisor_map_editor::save_tilesmap ()
       map++;
       buffer += 2;
     }
-#ifdef WIN32
   /* set umask so that files are group-writable */
-  _umask (0002);
-#else
   umask (0002);
-#endif
   const char *
   filename = "edmap.data";
   Sint32
@@ -848,9 +844,6 @@ bool supervisor_map_editor::save_tilesmap ()
   left = bytes_size;
   while (left > 0)
     {
-#ifdef WIN32
-      bytes_written = _write (handle, filedata + bytes_size - left, left);
-#else
       bytes_written = write (handle, filedata + bytes_size - left, left);
       if (bytes_written == -1)
        {
@@ -862,7 +855,6 @@ bool supervisor_map_editor::save_tilesmap ()
        }
       left -= bytes_written;
     }
-#endif
   if (close (handle) == -1)
     {
       std::cerr << "supervisor_map_editor::save_tilesmap() file " <<


### PR DESCRIPTION
Some bugs fixed:
- Close file tecnoballz.conf after creation
- Create tecnoballz.conf with default values if it's absent
- remove forgotten SCROREFILE define from tecnoballz.h
- remove some WIN32-specific code in creation of tecnoballz.hi (not needed, common code works)
- remove checking for malloc as it checks not for malloc presence but if malloc(0) returns valid pointer. And malloc is not used at all in game code.