### PR TITLE
handler_audio.cc: Don't rely on SDL_mixer using libmikmod

### DIFF
--- a/include/handler_audio.h
+++ b/include/handler_audio.h
@@ -197,8 +197,6 @@ private:
   Uint32 channels_volume;
   /** Identifier of the current music loaded and played */
   Sint32 current_music_id;
-  /** Pointer to the current music loaded and played */
-  Mix_Music *current_music;
   /** Pointer to the Amiga song module (Protracker format) */
   MODULE *song_module;
   /** Size of all waves used for sounds effect */


### PR DESCRIPTION
As on different platforms it may use libmodplug.
Instead, use mikmod directly for music and catch output with
Mix_HookMusic().

This is pretty hacky as 'no sound' driver is used with
direct calling to VC_WriteBytes() to fill the buffer.

MikMod_RegisterAllLoaders() fail for some platforms so use
MikMod_RegisterLoader() separately.

Register .xm loader as well as .mod because area1-game2.mod is .xm
in disguise.
